### PR TITLE
use stable terra user interface

### DIFF
--- a/R/spatial.R
+++ b/R/spatial.R
@@ -33,14 +33,17 @@ is_spatial <- function(x) {
     }
   }
   if (is.na(crs) && (inherits(x, "SpatRaster") || inherits(x, "SpatVector"))) {
-    crs <- try(x@ptr$get_crs("wkt"), silent = TRUE)
-    if (inherits(crs, "try-error")) {
-      crs <- NA_character_
-    }
+    #crs <- try(x@ptr$get_crs("wkt"), silent = TRUE)
+    crs <- terra::crs(x)
+	## This should never happen?
+	#if (inherits(crs, "try-error")) {
+    #  crs <- NA_character_
+    #}
     
     if (is.na(crs)) {
-      if (x@ptr$isLonLat()) {
-        crs <- "+proj=longlat +datum=WGS84"
+#      if (x@ptr$isLonLat()) {
+	  if (is.lonlat(x, perhaps=FALSE, warn=FALSE)) {
+		crs <- "+proj=longlat +datum=WGS84"
       }
     }
   }


### PR DESCRIPTION
The `x@ptr$...` idiom is not part of the stable user interface of "terra" (because that would make it very difficult to make changes without breaking downstream packages). And this now breaks on CRAN. This PR should fix that.